### PR TITLE
fix force close, remove manual formatting for date time

### DIFF
--- a/app/src/main/java/com/example/personalapp/MyAdapter.java
+++ b/app/src/main/java/com/example/personalapp/MyAdapter.java
@@ -71,7 +71,7 @@ public class MyAdapter extends RecyclerView.Adapter<MyAdapter.MyViewHolder>{
             holder.text3.setTextColor(context.getResources().getColor(R.color.darkYellow));
             holder.text3.setBackgroundResource(R.color.softYellow);
         }
-        holder.text4.setText(listDate.get(position).substring(0 , listDate.get(position).indexOf(".")));
+        holder.text4.setText(listDate.get(position));
 
         holder.text5.setText(listMethod.get(position));
 


### PR DESCRIPTION
This commit try to fix bug force close after there is an update from BE corresponding with requestTime format. From mobile side, no need to manually format the datetime anymore, it has been done from the BE side.